### PR TITLE
データの有効期限切れチェックの際にArrayIndexOutOfBoundsException

### DIFF
--- a/src/okuyama/imdst/util/KeyMapManager.java
+++ b/src/okuyama/imdst/util/KeyMapManager.java
@@ -677,7 +677,6 @@ public class KeyMapManager extends Thread {
                             if (checkValueSplit.length > 1) {
 
                                 String[] metaColumns = checkValueSplit[1].split(ImdstDefine.valueMetaColumnSep);
-                                logger.info("VacuumInvalidData - checkMetaColumns - " + Arrays.toString(metaColumns));
                                 if (metaColumns.length > 1 && !SystemUtil.expireCheck(metaColumns[1], ImdstDefine.invalidDataDeleteTime)) {
 
                                     // 無効データは削除

--- a/src/okuyama/imdst/util/KeyMapManager.java
+++ b/src/okuyama/imdst/util/KeyMapManager.java
@@ -677,7 +677,8 @@ public class KeyMapManager extends Thread {
                             if (checkValueSplit.length > 1) {
 
                                 String[] metaColumns = checkValueSplit[1].split(ImdstDefine.valueMetaColumnSep);
-                                if (!SystemUtil.expireCheck(metaColumns[1], ImdstDefine.invalidDataDeleteTime)) {
+                                logger.info("VacuumInvalidData - checkMetaColumns - " + Arrays.toString(metaColumns));
+                                if (metaColumns.length > 1 && !SystemUtil.expireCheck(metaColumns[1], ImdstDefine.invalidDataDeleteTime)) {
 
                                     // 無効データは削除
                                     this.removeKeyPair((String)key, "0");


### PR DESCRIPTION
有効期限が過ぎたデータの削除チェック(VacuumInvalidData)する際にArrayIndexOutOfBoundsExceptionが発生してDataNodeが強制終了してしまいます。

metaCoulmnの内容をログにダンプしてみたところ、metaColumnが要素数１となる場合がありました。
この時に添字1のデータを参照しようとして例外が発生しています。

解析用に追加したログの出力は下のようになります。

```
2014-09-15 16:14:25,055  INFO KeyMapManager - VacuumInvalidData - Start - 1
2014-09-15 16:14:25,055  INFO KeyMapManager - VacuumInvalidData - checkMetaColumns - [3]
2014-09-15 16:14:25,056  INFO KeyMapManager - VacuumInvalidData - checkMetaColumns - [0, 0, 0]
2014-09-15 16:14:25,059  INFO KeyMapManager - VacuumInvalidData - checkMetaColumns - [0, 0, 0]
2014-09-15 16:14:25,091  INFO KeyMapManager - VacuumInvalidData - checkMetaColumns - [0, 0, 0]
2014-09-15 16:14:25,091  INFO KeyMapManager - RemoveInvalidData - Count [0]
2014-09-15 16:14:25,091  INFO KeyMapManager - VacuumInvalidData - End - 1
```

回避策として metaColumnの要素が1より大きい(2以上)の時にのみチェックを行うようにしました。
